### PR TITLE
Non-zero exit status when the API returns an error for the application.

### DIFF
--- a/generate_sbom.py
+++ b/generate_sbom.py
@@ -49,6 +49,8 @@ def main():
               print(json.dumps(sbom), file=f)
     if (not found):
        print ('App: '+args.app+' does not exist')
+       exit(1)
+
     exit(0)
 
 if __name__ == '__main__':


### PR DESCRIPTION
If the app doesn't exist, or there are no recent enough scans, the script exits with an error.